### PR TITLE
add TransportError for network errors

### DIFF
--- a/lib/scorm_cloud/base.rb
+++ b/lib/scorm_cloud/base.rb
@@ -85,7 +85,7 @@ module ScormCloud
       when Net::HTTPSuccess
         res.body
       else
-        raise "HTTP Error connecting to scorm cloud: #{res.inspect}"
+        raise TransportError.new(res)
       end
     end
 

--- a/lib/scorm_cloud/error.rb
+++ b/lib/scorm_cloud/error.rb
@@ -22,6 +22,15 @@ module ScormCloud
     end
   end
 
+  class TransportError < Error
+    attr_reader :response
+
+    def initialize(response)
+      @response = response
+      super("Transport error: #{response.inspect}")
+    end
+  end
+
   class InvalidPackageError < Error
     def initialize
       super('Not a valid SCORM package')


### PR DESCRIPTION
transport errors have no distinguishing exception class, this makes it difficult to handle such errors