### PR TITLE
Add logging functionality for request/response

### DIFF
--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe "Logging" do
+  describe ScormCloud::ScormCloud.new($scorm_cloud_appid,$scorm_cloud_secret) do
+    it "should not log by default" do
+      logger = double("logger", 'nil?' => true) # odd, but necessary to test expectations
+      subject.logger = logger
+      expect(subject).to receive(:log_request_response).and_call_original
+      expect(logger).not_to receive(:debug)
+      subject.debug.ping
+    end
+
+    it "should log if configured to do so" do
+      logger = double("logger")
+      subject.logger = logger
+      expect(subject).to receive(:log_request_response).and_call_original
+      expect(logger).to receive(:debug).twice
+      subject.debug.ping
+    end
+  end
+end


### PR DESCRIPTION
Default behavior is to not log anything.

A fourth argument has been added to the initialization method that
expects a Logger (or any object that quacks like a Logger).

Alternatively you can instantiate the scorm object and then set
`logger`.

If set, the HTTP request and response will be written to the log.