### PR TITLE
Add ability to specify custom SCORM API url and other minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ This ruby gem is provides a ruby interface to the Rustici Scorm Cloud.
 ## Shell CLI Interface
 
 $ `gem install scorm_cloud`  
-$ `scorm_cloud rustici.course.getCourseList —appid myappid —secret mysecret`
+$ `scorm_cloud rustici.course.getCourseList -—appid myappid -—secret mysecret`
+$ `scorm_cloud rustici.course.getMetadata --courseid a-valid-course-id-12345`
 
 
 ## Standard Ruby Use
 
     require 'scorm_cloud'
     sc = ScormCloud::ScormCloud.new("my_app_id", "my_secret_key")
+    # sc = ScormCloud::ScormCloud.new("my_app_id", "my_secret_key", "http://custom/api/url")
+    # sc = ScormCloud::ScormCloud.new("my_app_id", "my_secret_key", "http://custom/api/url", custom_logger)
     sc.course.get_course_list.each { |c| puts "#{c.id} #{c.title}"}
 
 
@@ -30,6 +33,7 @@ $ `scorm_cloud rustici.course.getCourseList —appid myappid —secret mysecret`
     MyApplication::Application.configure do |config|
       config.scorm_cloud.appid = "my_app_id"
       config.scorm_cloud.secretkey = "my_secret_key"
+      # config.scorm_cloud.api_url = "http://custom/api/url"
     end
 
 *Place the following in: app/controllers.course_controller.rb*

--- a/lib/scorm_cloud/CLI.rb
+++ b/lib/scorm_cloud/CLI.rb
@@ -2,8 +2,9 @@ module ScormCloud
   class CLI
     def self.start
       command = ARGV.shift
-      appid = ENV['SCORM-CLOUD-APPID']
-      secret = ENV['SCORM-CLOUD-SECRET']
+      appid = ENV['SCORM-CLOUD-APPID'] || ENV['SCORM_CLOUD_APPID']
+      secret = ENV['SCORM-CLOUD-SECRET'] || ENV['SCORM_CLOUD_SECRET']
+      api_url = ENV['SCORM-CLOUD-API-URL'] || ENV['SCORM_CLOUD_API_URL']
       opts = {}
       while ARGV.length > 0
         case ARGV[0]
@@ -11,13 +12,15 @@ module ScormCloud
             ARGV.shift; appid = ARGV.shift
           when '--secret'
             ARGV.shift; secret = ARGV.shift
+          when '--api-url'
+            ARGV.shift; api_url = ARGV.shift
           else
             name = ARGV.shift[2..-1].to_sym
             value = ARGV.shift
             opts[name] = value
           end
         end
-        sc = ScormCloud.new(appid, secret)
+        sc = ScormCloud.new(appid, secret, api_url)
         puts sc.call(command, opts)
     end
   end

--- a/lib/scorm_cloud/base.rb
+++ b/lib/scorm_cloud/base.rb
@@ -3,10 +3,10 @@ module ScormCloud
     attr_reader :appid, :api_url
     attr_accessor :logger
 
-    def initialize(appid, secret, api_url="https://cloud.scorm.com/api", logger=nil)
+    def initialize(appid, secret, api_url=nil, logger=nil)
       @appid = appid
       @secret = secret
-      @api_url = api_url
+      @api_url = api_url || "https://cloud.scorm.com/api"
       @logger = logger
     end
 

--- a/lib/scorm_cloud/error.rb
+++ b/lib/scorm_cloud/error.rb
@@ -6,7 +6,7 @@ module ScormCloud
     attr_reader :code, :msg, :url
 
     def initialize(doc, url)
-      err = doc.elements["rsp"].try(:elements).try(:[], "err")
+      err = extract_err(doc)
       if err
         code = err.attributes["code"]
         msg = err.attributes["msg"]
@@ -18,6 +18,16 @@ module ScormCloud
         doc_xml = ''
         doc.write(doc_xml)
         @msg = "Request failed with an unknown error. Entire response: #{doc_xml}"
+      end
+    end
+
+    private
+
+    def extract_err(doc)
+      if doc.elements["rsp"].respond_to?(:elements) && doc.elements["rsp"].elements.respond_to?(:[])
+        doc.elements["rsp"].elements["err"]
+      else
+        nil
       end
     end
   end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe "Rustici Web Service API" do
+  describe ScormCloud::ScormCloud do
+    describe "api_url" do
+      it "defaults to https://cloud.scorm.com/api" do
+        expect(described_class.new("appid", "secret").api_url).to eq "https://cloud.scorm.com/api"
+      end
+
+      it "falls back to https://cloud.scorm.com/api" do
+        expect(described_class.new("appid", "secret", nil).api_url).to eq "https://cloud.scorm.com/api"
+      end
+
+      it "can be overridden" do
+        expect(described_class.new("appid", "secret", "apiurl").api_url).to eq "apiurl"
+      end
+    end
+  end
+end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe "Rustici Web Service API" do
+  describe ScormCloud::RequestError do
+    let(:url) { "http://some.url" }
+
+    describe "known errors" do
+      let(:known_xml_error) { %q{<?xml version="1.0" encoding="utf-8" ?><rsp stat="ok"><err code="1" msg="oops"/></rsp>} }
+      let(:doc) { REXML::Document.new(known_xml_error) }
+      subject { described_class.new(doc, url) }
+
+      it "sets the code" do
+        expect(subject.code).to eq "1"
+      end
+
+      it "sets the msg" do
+        expect(subject.msg).to eq "oops"
+      end
+
+      it "builds the error message" do
+        expect(subject.to_s).to match(/error in scorm cloud: error=1 message=oops url=/i)
+      end
+    end
+
+    describe "handles unknown errors" do
+      let(:unknown_xml_error) { %q{<?xml version="1.0" encoding="utf-8" ?><rsp stat="ok"><bogus/></rsp>} }
+      let(:doc) { REXML::Document.new(unknown_xml_error) }
+      subject { described_class.new(doc, url) }
+
+      it "deos not set the code" do
+        expect(subject.code).to eq nil
+      end
+
+      it "builds a generic error message" do
+        expect(subject.msg).to match(/request failed with an unknown error. entire response: .*<bogus\/>/i)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
- Added the ability to specify a custom SCORM API url via an ENV var.

- Added undercased versions of ENV vars so they are usable on the
  command line.

- Replaced use of `try` which is Rails specific with Ruby begin/rescue
  handler.

- Updated README to reflect above changes and fix some inaccuracies.