### PR TITLE
Implement course's import_course_async and get_async_import_result methods

### DIFF
--- a/features/course_service.feature
+++ b/features/course_service.feature
@@ -17,3 +17,16 @@ Feature: Course Service Interface
     When I import a course
     And I update course attributes
     Then the course attributes should be updated
+
+  Scenario: A user can async import a course
+    When I import a course asynchronously
+    Then the async import result status will be "running"
+    And the course will eventually be imported
+    And the async import result status will be "finished"
+    And the course should exist
+
+  Scenario: A user can not async import a bad course
+    When I import a bad course asynchronously
+    Then the course will eventually fail to import
+    And the async import result status will be "error"
+

--- a/features/step_definitions/scorm_cloud_steps.rb
+++ b/features/step_definitions/scorm_cloud_steps.rb
@@ -148,7 +148,6 @@ When /^I import a course asynchronously$/ do
   @last_course_id = "small_scorm_course_#{rand(1000)}"
   hash = @c.course.import_course_async(@last_course_id, @last_uploaded_path)
   @last_async_token = hash[:token]
-  expect(hash).to_not be_nil
   expect(hash[:token]).to_not be_nil
 end
 
@@ -156,7 +155,6 @@ When /^I import a bad course asynchronously$/ do
   @last_course_id = "small_scorm_course_#{rand(1000)}"
   hash = @c.course.import_course_async(@last_course_id, "bogus-file-path")
   @last_async_token = hash[:token]
-  expect(hash).to_not be_nil
   expect(hash[:token]).to_not be_nil
 end
 

--- a/lib/scorm_cloud/course_service.rb
+++ b/lib/scorm_cloud/course_service.rb
@@ -3,11 +3,19 @@ module ScormCloud
     not_implemented :properties, :get_assets, :update_assets, :get_file_structure, :delete_files
 
     # See http://cloud.scorm.com/doc/web-services/api.html#rustici.course.getAsyncImportResult
+    #
+    # The XML for error responses looks like this:
+    #
+    #   <?xml version='1.0' encoding='UTF-8'?>
+    #   <rsp stat='ok'>
+    #     <status>error</status>
+    #     <error code='2'><![CDATA[Course zip file not found]]></error>
+    #   </rsp>
     def get_async_import_result(token)
       xml = connection.call("rustici.course.getAsyncImportResult", :token => token)
 
       status = xml.elements["//rsp/status"].text.downcase
-      response = { :status => status.downcase }
+      response = { :status => status }
 
       case status
       when "error"

--- a/lib/scorm_cloud/course_service.rb
+++ b/lib/scorm_cloud/course_service.rb
@@ -1,8 +1,44 @@
 module ScormCloud
   class CourseService < BaseService
-    not_implemented :import_cours_async, :get_async_import_result,
-      :properties, :get_assets, :update_assets,
-      :get_file_structure, :delete_files
+    not_implemented :properties, :get_assets, :update_assets, :get_file_structure, :delete_files
+
+    # See http://cloud.scorm.com/doc/web-services/api.html#rustici.course.getAsyncImportResult
+    def get_async_import_result(token)
+      xml = connection.call("rustici.course.getAsyncImportResult", :token => token)
+
+      status = xml.elements["//rsp/status"].text.downcase
+      response = { :status => status.downcase }
+
+      case status
+      when "error"
+        response.merge!({
+          :error_code => xml.elements["//rsp/error"].attributes["code"],
+          :error_msg => xml.elements["//rsp/error"].text,
+        })
+      when "finished"
+        response.merge!(process_importresult(xml))
+      end
+
+      response
+    end
+
+    # See http://cloud.scorm.com/doc/web-services/api.html#rustici.course.importCourseAsync
+    def import_course_async(course_id, file)
+      if file.respond_to? :read
+        xml = connection.post("rustici.course.importCourseAsync", file, :courseid => course_id)
+      else
+        xml = connection.call("rustici.course.importCourseAsync", :courseid => course_id, :path => file)
+      end
+
+      if xml.elements['//rsp/token/id']
+        token = xml.elements['//rsp/token/id'].text
+        { :token => token }
+      else
+        # The API docs aren't at all clear what happens if this call fails and
+        # I haven't found a way to trigger an error. So for now, nil will have to suffice.
+        nil
+      end
+    end
 
     # TODO: Handle Warnings
     def import_course(course_id, file)
@@ -12,23 +48,7 @@ module ScormCloud
         xml = connection.call("rustici.course.importCourse", :courseid => course_id, :path => file)
       end
 
-      if xml.elements['//rsp/importresult'] && xml.elements['//rsp/importresult'].attributes["successful"] == "true"
-        title = xml.elements['//rsp/importresult/title'].text 
-        { :title => title, :warnings => [] }
-      else
-        # Package wasn't a zip file at all
-        invalid = xml.elements['//rsp/importresult'].nil?
-        # Package was a zip file that wasn't a SCORM package
-        invalid ||= xml.elements['//rsp/importresult/message'] && xml.elements['//rsp/importresult/message'].text == 'zip file contained no courses'
-
-        if invalid
-          raise InvalidPackageError
-        else
-          xml_text = ''
-          xml.write(xml_text)
-          raise "Not successful. Response: #{xml_text}"
-        end
-      end
+      process_importresult(xml)
     end
 
     def exists(course_id)
@@ -66,6 +86,28 @@ module ScormCloud
     def get_metadata(course_id, scope='course')
       xml = connection.call("rustici.course.getMetadata", courseid: course_id, scope: scope)
       xml.elements['/rsp/package']
+    end
+
+    private
+
+    def process_importresult(xml)
+      if xml.elements['//rsp//importresult'] && xml.elements['//rsp//importresult'].attributes["successful"] == "true"
+        title = xml.elements['//rsp//importresult/title'].text 
+        { :title => title, :warnings => [] }
+      else
+        # Package wasn't a zip file at all
+        invalid = xml.elements['//rsp//importresult'].nil?
+        # Package was a zip file that wasn't a SCORM package
+        invalid ||= xml.elements['//rsp//importresult/message'] && xml.elements['//rsp//importresult/message'].text == 'zip file contained no courses'
+
+        if invalid
+          raise InvalidPackageError
+        else
+          xml_text = ''
+          xml.write(xml_text)
+          raise "Not successful. Response: #{xml_text}"
+        end
+      end
     end
   end
 end

--- a/spec/course_service_spec.rb
+++ b/spec/course_service_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe "Rustici Web Service API" do
   describe ScormCloud::ScormCloud.new($scorm_cloud_appid,$scorm_cloud_secret).course do
+    it { should respond_to(:get_async_import_result).with(1).arguments }
+    it { should respond_to(:import_course_async).with(2).arguments }
     it { should respond_to(:import_course).with(2).arguments }
     it { should respond_to(:preview).with(2).argument }
     it { should respond_to(:delete_course).with(1).arguments }
@@ -15,11 +17,9 @@ describe "Rustici Web Service API" do
     # Not Implemented
     it { should respond_to(:get_assets).with(0).arguments }
     it { should respond_to(:update_assets).with(0).arguments }
-    it { should respond_to(:import_cours_async).with(0).arguments }
-    it { should respond_to(:get_async_import_result).with(0).arguments }
     it { should respond_to(:properties).with(0).arguments }
     it { should respond_to(:get_file_structure).with(0).arguments }
     it { should respond_to(:delete_files).with(0).arguments }
-    it { should respond_to(:get_metadata).with(0).arguments }
+    it { should respond_to(:get_metadata).with(1).arguments }
   end
 end


### PR DESCRIPTION
Adds functionality to support importing courses asynchronously.

http://cloud.scorm.com/doc/web-services/api.html#rustici.course.importCourseAsync
http://cloud.scorm.com/doc/web-services/api.html#rustici.course.getAsyncImportResult

This is necessary in our application as SCORM engine otherwise tries to
process the course inline and the upstream web server times out making
our app think the import failed. Async gets around this.