### PR TITLE
add tagging support for courses and learners

### DIFF
--- a/lib/scorm_cloud/tagging_service.rb
+++ b/lib/scorm_cloud/tagging_service.rb
@@ -1,8 +1,46 @@
 module ScormCloud
   class TaggingService < BaseService
-    not_implemented :get_course_tags, :set_course_tags, :add_course_tag,
-      :remove_course_tag, :get_learner_tags, :set_learner_tags, :add_learner_tag,
-      :remove_learner_tag, :get_registration_tags, :set_registration_tags,
-      :add_registration_tag, :remove_registration_tag
+    not_implemented :get_registration_tags, :set_registration_tags,
+                    :add_registration_tag, :remove_registration_tag
+
+    def get_course_tags(course_id)
+      xml = connection.call("rustici.tagging.getCourseTags", { :courseid => course_id })
+      xml.elements['/rsp/tags'].map(&:text)
+    end
+
+    def set_course_tags(course_id, tags)
+      xml = connection.call("rustici.tagging.setCourseTags", { :courseid => course_id, tags: tags })
+      !xml.elements['/rsp/success'].nil?
+    end
+
+    def add_course_tag(course_id, tag)
+      xml = connection.call("rustici.tagging.addCourseTag", { :courseid => course_id, tag: tag })
+      !xml.elements['/rsp/success'].nil?
+    end
+
+    def remove_course_tag(course_id, tag)
+      xml = connection.call("rustici.tagging.removeCourseTag", { :courseid => course_id, tag: tag })
+      !xml.elements['/rsp/success'].nil?
+    end
+
+    def get_learner_tags(learner_id)
+      xml = connection.call("rustici.tagging.getLearnerTags", { :learnerid => learner_id })
+      xml.elements['/rsp/tags'].map(&:text)
+    end
+
+    def set_learner_tags(learner_id, tags)
+      xml = connection.call("rustici.tagging.setLearnerTags", { :learnerid => learner_id, tags: tags })
+      !xml.elements['/rsp/success'].nil?
+    end
+
+    def add_learner_tag(learner_id, tag)
+      xml = connection.call("rustici.tagging.addLearnerTag", { :learnerid => learner_id, tag: tag })
+      !xml.elements['/rsp/success'].nil?
+    end
+
+    def remove_learner_tag(learner_id, tag)
+      xml = connection.call("rustici.tagging.removeLearnerTag", { :learnerid => learner_id, tag: tag })
+      !xml.elements['/rsp/success'].nil?
+    end
   end
 end

--- a/spec/tagging_service_spec.rb
+++ b/spec/tagging_service_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe "Rustici Web Service API" do
   describe ScormCloud::ScormCloud.new($scorm_cloud_appid,$scorm_cloud_secret).tagging do
-    it { should respond_to(:get_course_tags) }
-    it { should respond_to(:set_course_tags) }
-    it { should respond_to(:add_course_tag) }
-    it { should respond_to(:remove_course_tag) }
-    it { should respond_to(:get_learner_tags) }
-    it { should respond_to(:set_learner_tags) }
-    it { should respond_to(:add_learner_tag) }
-    it { should respond_to(:remove_learner_tag) }
+    it { should respond_to(:get_course_tags).with(1).arguments }
+    it { should respond_to(:set_course_tags).with(2).arguments }
+    it { should respond_to(:add_course_tag).with(2).arguments }
+    it { should respond_to(:remove_course_tag).with(2).arguments }
+    it { should respond_to(:get_learner_tags).with(1).arguments }
+    it { should respond_to(:set_learner_tags).with(2).arguments }
+    it { should respond_to(:add_learner_tag).with(2).arguments }
+    it { should respond_to(:remove_learner_tag).with(2).arguments }
     it { should respond_to(:get_registration_tags) }
     it { should respond_to(:set_registration_tags) }
     it { should respond_to(:add_registration_tag) }


### PR DESCRIPTION
This implements the tagging service for courses and learners. I would do
it for registrations, but in local testing, while the methods work, they
never actually set any tags so I opted to leave them out.

I've attached an example test script, it's output, and the raw SCORM log should that be useful.

[test-script-rb.txt](https://github.com/instructure/scorm-cloud/files/1794822/test-script-rb.txt)
[test-output.txt](https://github.com/instructure/scorm-cloud/files/1794819/test-output.txt)
[scorm-log.log](https://github.com/instructure/scorm-cloud/files/1794821/scorm-log.log)

https://cloud.scorm.com/docs/api_reference/tagging.html
